### PR TITLE
Fix test failures on Windows due to command line arg issues

### DIFF
--- a/t/lib/VimTest.pm
+++ b/t/lib/VimTest.pm
@@ -13,11 +13,20 @@ BEGIN {
     exit;
 END
 
-    exec 'vim', qw/ -V -u NONE -i NONE -N -e -s /,
-        '-c' => 'perl unshift @INC, "lib"', 
-        '-c' => 'perl unshift @INC, "t/lib"', 
-        '-c', "perl do '$0'",
-        '-c', "qall!";
+    if ($^O ne 'MSWin32') {
+        exec 'vim', qw/ -V -u NONE -i NONE -N -e -s /,
+            '-c' => 'perl unshift @INC, "lib"',
+            '-c' => 'perl unshift @INC, "t/lib"',
+            '-c', "perl do '$0'",
+            '-c', "qall!";
+    }
+    else {
+        exec 'vim', qw/ -V -u NONE -i NONE -N -e -s /,
+            '-c' => q{"perl unshift @INC, 'lib'"},
+            '-c' => q{"perl unshift @INC, 't/lib'"},
+            '-c', qq{"perl do '$0'"},
+            '-c', "qall!";
+    }
 }
 
 use parent 'Exporter';
@@ -27,7 +36,7 @@ our @EXPORT = ( 'in_window' );
 
 sub in_window (&) {
     my $code = shift;
-    sub { 
+    sub {
         vim_command('new');
         eval { ::test_setup() };
         $code->();


### PR DESCRIPTION
On Windows, even with `exec LIST`, things sometimes pass through the shell and are thus subject to the whims of `cmd.exe`. I added an extra level of quotation to handle this. I decided to isolate it with an OS
check because I have no idea how this would affect other environments.

There are some spurious **PASS** results on CPANTesters from Windows systems without a command line Vim.

HTH. Looking forward to having fun with the module.

With the patch, `Build test` gives:

<pre>t/000-report-versions-tiny.t .. ok
t/line.t ...................... t/line.t at t/lib/VimTest.pm line 7.
-e at t/lib/VimTest.pm line 7.
t/line.t ...................... ok
t/range.t ..................... t/range.t at t/lib/VimTest.pm line 7.
-e at t/lib/VimTest.pm line 7.
t/range.t ..................... ok
t/synopsis.t .................. t/synopsis.t at t/lib/VimTest.pm line 7.
-e at t/lib/VimTest.pm line 7.
variable name foo used 3 timesUse of uninitialized value $Vim::X::RETURN in concatenation (.) or string at (eval 32) line 1.
t/synopsis.t .................. ok
t/vim-x.t ..................... t/vim-x.t at t/lib/VimTest.pm line 7.
-e at t/lib/VimTest.pm line 7.
t/vim-x.t ..................... 1/7 "t/buffer"
t/vim-x.t ..................... ok
All tests successful.
Files=6, Tests=25,  5 wallclock secs ( 0.13 usr +  0.05 sys =  0.17 CPU)
Result: PASS</pre>


Running `Build test` with unpatched distro gave me:

<pre>t/000-report-versions-tiny.t .. ok
t/line.t ...................... t/line.t at t/lib/VimTest.pm line 7.
"unshift" [New File]
Error detected while processing command line:
E471: Argument required: perl
E471: Argument required: perl
t/line.t ...................... No subtests run
t/range.t ..................... t/range.t at t/lib/VimTest.pm line 7.
"unshift" [New File]
Error detected while processing command line:
E471: Argument required: perl
E471: Argument required: perl
t/range.t ..................... No subtests run
t/synopsis.t .................. t/synopsis.t at t/lib/VimTest.pm line 7.
"unshift" [New File]
Error detected while processing command line:
E471: Argument required: perl
E471: Argument required: perl
t/synopsis.t .................. No subtests run
t/vim-x.t ..................... t/vim-x.t at t/lib/VimTest.pm line 7.
"unshift" [New File]
Error detected while processing command line:
E471: Argument required: perl
E471: Argument required: perl
t/vim-x.t ..................... No subtests run

Test Summary Report
-------------------
t/line.t                    (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
t/range.t                   (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
t/synopsis.t                (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
t/vim-x.t                   (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
Files=6, Tests=8,  4 wallclock secs ( 0.11 usr +  0.03 sys =  0.14 CPU)
Result: FAIL
Failed 4/6 test programs. 0/8 subtests failed.</pre>
